### PR TITLE
fix(tabGenerator): missing semicolon imports

### DIFF
--- a/src/tab-generator.ts
+++ b/src/tab-generator.ts
@@ -118,7 +118,7 @@ export class TabGenerator extends Generator {
   createTabImports(tabs: string[]) {
     let importString = '';
     for (let i = 0; i < tabs.length; i++) {
-      importString = `${importString}import { ${stringToClassCase(tabs[i])} } from '../${kebabCase(tabs[i])}/${kebabCase(tabs[i])}'`
+      importString = `${importString}import { ${stringToClassCase(tabs[i])} } from '../${kebabCase(tabs[i])}/${kebabCase(tabs[i])}';`
       if (i !== tabs.length - 1) {
         // add a newline character
         importString = `${importString}\n`;


### PR DESCRIPTION
Related [#8208](https://github.com/driftyco/ionic/pull/8208) missing imports semicolon to variable $TAB_IMPORTS
