### PR TITLE
generator type now case insensitive to users input

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export function printAvailableGenerators() {
 }
 
 export function generate(options: GeneratorOptions, projectStructureOptions: ProjectStructureOptions): Promise<any>{
+  options.generatorType = options.generatorType.toLowerCase();
   const error = validateOptions(options, projectStructureOptions);
   if (error) {
     return Promise.reject(error);


### PR DESCRIPTION
As Referenced In https://github.com/driftyco/ionic-app-generators/issues/9
. 
Since the CONSTANTS for the Gen type are all lowercase, all I did here was make the user input all lowercase to match the utils for generatorType.

so if a user now does something like Pipes, PIPE or pipe it shouldn't make a difference as long as the spelling of the param is correct for the generatorType